### PR TITLE
Rsvp/internal endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+SLACK_BOT_TOKEN=your_slack_bot_token
+SLACK_SIGNING_SECRET=your_slack_signing_secret
+
+SLACK_APPROVAL_CHANNEL=your_approval_channel_id
+SLACK_SAD_CHANNEL=your_sad_channel_id
+
+AIRTABLE_API_KEY=your_airtable_api_key
+AIRTABLE_BASE_ID=your_airtable_base_id
+
+POSTGRES_PASSWORD=your_postgres_password
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+
+ENVIRONMENT=development
+
+# Generate with:
+# openssl rand -hex 32
+EVENTS_RSVP_SECRET=your_events_rsvp_secret

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To run the bot locally, you'll need to set up a Slack app and run a postgresql d
 - `GOOGLE_PASSWORD` - _the app password of the Google account to use for sending emails_
 - `PORT` - _optional, defaults to 3000_
 - `EVENTS_RSVP_SECRET` - the secret used for validating permissions for rsvp endpoints (generate with `openssl rand -hex 32`)
+
 For the Slack app, here is the manifest you will need. Make sure to change the command and request URLs.
 
 ```json

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To run the bot locally, you'll need to set up a Slack app and run a postgresql d
 - `GOOGLE_USERNAME` - _the email address of the Google account to use for sending emails_
 - `GOOGLE_PASSWORD` - _the app password of the Google account to use for sending emails_
 - `PORT` - _optional, defaults to 3000_
-
+- `EVENTS_RSVP_SECRET` - the secret used for validating permissions for rsvp endpoints (generate with `openssl rand -hex 32`)
 For the Slack app, here is the manifest you will need. Make sure to change the command and request URLs.
 
 ```json

--- a/app.py
+++ b/app.py
@@ -36,9 +36,14 @@ async def internal_rsvp(req: Request):
     event = await env.database.toggle_user_interest(event_id, slack_id, forced_state=attending)
     if not event:
         return JSONResponse({"error": "event not found or update failed"}, status_code=404)
-    is_attending = slack_id in (event.get("InterestedUsers") or [])
-    return JSONResponse({"attending": is_attending, "InterestCount": event.get("InterestCount", 0)})
-
+    if isinstance(event, dict):
+        interested = event.get("InterestedUsers") or []
+        count = event.get("InterestCount", 0)
+    else:
+        interested = event.InterestedUsers or []
+        count = event.InterestCount or 0
+    is_attending = slack_id in interested
+    return JSONResponse({ "attending": is_attending, "InterestCount": count })
 async def internal_rsvp_list(req: Request):
     if not _check_internal_secret(req):
         return JSONResponse({"error": "unauthorized"}, status_code=401)

--- a/app.py
+++ b/app.py
@@ -15,7 +15,6 @@ from isabelle.tables import Event
 from slack_bolt.adapter.starlette.async_handler import AsyncSlackRequestHandler
 from isabelle.utils.slack import app 
 from isabelle.utils import rsvp_checker
-
 import logging
 import secrets
 from isabelle.utils.env import env
@@ -31,9 +30,25 @@ async def internal_rsvp(req: Request):
     body = await req.json()
     slack_id = body.get("slack_id")
     attending = body.get("attending")
+    user_info = body.get("user_info")
+
     if not slack_id or not isinstance(attending, bool):
         return JSONResponse({"error": "slack_id and boolean attending required"}, status_code=422)
-    event = await env.database.toggle_user_interest(event_id, slack_id, forced_state=attending)
+    
+    if user_info and attending:
+        try:
+            slack_user = await app._async_client.users_info(user=slack_id)
+            profile = slack_user["user"]["profile"]
+            user_info["slackDisplayName"] = (
+                profile.get("display_name")
+                or profile.get("real_name")
+                or None
+            )
+        except Exception as e:
+            logging.warning("Could not resolve slack display name for %s: %s", slack_id, e)
+            user_info["slackDisplayName"] = None
+
+    event = await env.database.toggle_user_interest(event_id, slack_id, forced_state=attending,user_info=user_info,)
     if not event:
         return JSONResponse({"error": "event not found or update failed"}, status_code=404)
     if isinstance(event, dict):
@@ -42,7 +57,14 @@ async def internal_rsvp(req: Request):
     else:
         interested = event.InterestedUsers or []
         count = event.InterestCount or 0
-    is_attending = slack_id in interested
+
+    rsvp_data = event.get("RSVPData") or {}
+    legacy_users = (event.get("InterestedUsers") or []) if isinstance(event, dict) else (event.InterestedUsers or [])
+    sub = (user_info or {}).get("sub")
+    in_rsvp = (sub and sub in rsvp_data) or any (
+        v.get("slackId") == slack_id for v in rsvp_data.values()
+    )
+    is_attending = in_rsvp or (slack_id in legacy_users)
     return JSONResponse({ "attending": is_attending, "InterestCount": count })
 async def internal_rsvp_list(req: Request):
     if not _check_internal_secret(req):
@@ -51,8 +73,21 @@ async def internal_rsvp_list(req: Request):
     event = await env.database.get_event(event_id)
     if not event:
         return JSONResponse({"error": "event not found"}, status_code=404)
-    users = list(event.get("InterestedUsers") or [])
-    return JSONResponse({"InterestedUsers": users, "InterestCount": event.get("InterestCount", 0)})
+    
+    legacy_users: list = list(event.get("InterestedUsers") or [])
+    rsvp_data: dict = dict(event.get("RSVPData") or {})
+    rsvp_slack_ids = {v.get("slackId") for v in rsvp_data.values() if v.get("slackId")}
+    for slack_id in legacy_users:
+        if slack_id not in rsvp_slack_ids:
+            rsvp_data[slack_id] = {
+                "sub": None,
+                "slackId": slack_id,
+                "name": None,
+                "email": None,
+                "slackDisplayName": None,
+                "rsvpedAt": None
+            }
+    return JSONResponse({ "attendees": list(rsvp_data.values()), "InterestCount": event.get("InterestCount", 0) })
 
 engine = None
 

--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ async def internal_rsvp(req: Request):
         return JSONResponse({"error": "unauthorized"}, status_code=401)
     event_id = req.path_params["event_id"]
     body = await req.json()
-    slack_id = body.get("slack.id")
+    slack_id = body.get("slack_id")
     attending = body.get("attending")
     if not slack_id or not isinstance(attending, bool):
         return JSONResponse({"error": "slack_id and boolean attending required"}, status_code=422)

--- a/app.py
+++ b/app.py
@@ -17,7 +17,37 @@ from isabelle.utils.slack import app
 from isabelle.utils import rsvp_checker
 
 import logging
+import secrets
+from isabelle.utils.env import env
 
+def _check_internal_secret(req: Request) -> bool:
+    provided = req.headers.get("x-internal-secret", "")
+    return secrets.compare_digest(provided, env.events_rsvp_secret)
+
+async def internal_rsvp(req: Request):
+    if not _check_internal_secret(req):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    event_id = req.path_params["event_id"]
+    body = await req.json()
+    slack_id = body.get("slack.id")
+    attending = body.get("attending")
+    if not slack_id or not isinstance(attending, bool):
+        return JSONResponse({"error": "slack_id and boolean attending required"}, status_code=422)
+    event = await env.database.toggle_user_interest(event_id, slack_id, forced_state=attending)
+    if not event:
+        return JSONResponse({"error": "event not found or update failed"}, status_code=404)
+    is_attending = slack_id in (event.get("InterestedUsers") or [])
+    return JSONResponse({"attending": is_attending, "InterestCount": event.get("InterestCount", 0)})
+
+async def internal_rsvp_list(req: Request):
+    if not _check_internal_secret(req):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    event_id = req.path_params["event_id"]
+    event = await env.database.get_event(event_id)
+    if not event:
+        return JSONResponse({"error": "event not found"}, status_code=404)
+    users = list(event.get("InterestedUsers") or [])
+    return JSONResponse({"InterestedUsers": users, "InterestCount": event.get("InterestCount", 0)})
 
 engine = None
 
@@ -86,7 +116,9 @@ api = Starlette(
         Mount("/static/", StaticFiles(directory="static")),
         Mount("/events/", PiccoloCRUD(table=Event,read_only=True,page_size=1000)),
         Route("/slack/events",endpoint=endpoint,methods=["POST"]),
-        Route("/health",endpoint=health,methods=["GET"])
+        Route("/health",endpoint=health,methods=["GET"]),
+        Route("/internal/events/{event_id}/rsvp", endpoint=internal_rsvp, methods=["PUT"]),
+        Route("/internal/events/{event_id}/rsvps", endpoint=internal_rsvp_list, methods=["GET"]),
     ],
     lifespan=lifespan,
 )

--- a/isabelle/piccolo_migrations/isabelle_rsvpdata_migration.py
+++ b/isabelle/piccolo_migrations/isabelle_rsvpdata_migration.py
@@ -1,0 +1,31 @@
+from piccolo.apps.migrations.auto.migration_manager import MigrationManager
+from piccolo.columns.column_types import JSONB
+
+ID = "isabelle_rsvpdata_migration"
+VERSION = "1.28.0"
+DESCRIPTION = "adds the RSVPData column"
+
+async def forwards():
+    manager = MigrationManager(
+        migration_id=ID, app_name="isabelle", description=DESCRIPTION
+    )
+    manager.add_column(
+        table_class_name="Event",
+        tablename="event",
+        column_name="RSVPData",
+        db_column_name="RSVPData",
+        column_class_name="JSONB",
+        column_class=JSONB,
+        params={
+            "default": {},
+            "null": False,
+            "primary_key": False,
+            "unique": False,
+            "index": False,
+            "choices": None,
+            "db_column_name": None,
+            "secret": False,
+        },
+        schema=None,
+    )
+    return manager

--- a/isabelle/tables.py
+++ b/isabelle/tables.py
@@ -39,7 +39,7 @@ class Event(Table):
     RawCancellation = Text(null=True)
     # I'm not ready for DB relations and I think a ID's list will work
     # TODO: implement notify by email
-    InterestedUsers = Array(base_column=Text(),default=[])
+    InterestedUsers = Array(base_column=Text(),default=[], secret=True)
     InterestCount = SmallInt() # I know this could easily be calculated but I will try to keep this as close to the airtable as possible
     rsvpMsg = Text(null=True)
     Tags = Array(base_column=Text(), default=[])

--- a/isabelle/tables.py
+++ b/isabelle/tables.py
@@ -40,7 +40,7 @@ class Event(Table):
     # I'm not ready for DB relations and I think a ID's list will work
     # TODO: implement notify by email
     InterestedUsers = Array(base_column=Text(),default=[], secret=True)
-    RSVPData = JSONB(default={})
+    RSVPData = JSONB(default={}, secret=True)
     InterestCount = SmallInt() # I know this could easily be calculated but I will try to keep this as close to the airtable as possible
     rsvpMsg = Text(null=True)
     Tags = Array(base_column=Text(), default=[])

--- a/isabelle/tables.py
+++ b/isabelle/tables.py
@@ -1,5 +1,5 @@
 from piccolo.table import Table
-from piccolo.columns import Varchar,Boolean,Timestamp, SmallInt, Text, Array, UUID
+from piccolo.columns import Varchar,Boolean,Timestamp, SmallInt, Text, Array, UUID, JSONB
 
 
 # Schema copied form airtable using PascalCase
@@ -40,6 +40,7 @@ class Event(Table):
     # I'm not ready for DB relations and I think a ID's list will work
     # TODO: implement notify by email
     InterestedUsers = Array(base_column=Text(),default=[], secret=True)
+    RSVPData = JSONB(default={})
     InterestCount = SmallInt() # I know this could easily be calculated but I will try to keep this as close to the airtable as possible
     rsvpMsg = Text(null=True)
     Tags = Array(base_column=Text(), default=[])

--- a/isabelle/utils/database.py
+++ b/isabelle/utils/database.py
@@ -1,12 +1,11 @@
 from datetime import datetime, timezone
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Any
 import uuid
 import json
 import logging
 from urllib.parse import quote
 
 from isabelle.tables import Event
-
 
 def get_cachet_pfp(user_id: str) -> str:
     return f"https://cachet.dunkirk.sh/users/{user_id}/r"
@@ -45,6 +44,7 @@ class DatabaseService:
             Avatar=avatar_url or get_cachet_pfp(leader_slack_id),
             EventLink=event_link or "https://app.slack.com/huddle/T0266FRGM/C01D7AHKMPF",
             Approved=approved,
+            RSVPData = {},
             Cancelled=False,
             InterestedUsers=[],
             InterestCount=0,
@@ -71,7 +71,7 @@ class DatabaseService:
     async def get_event(self, event_id: str) -> Optional[Event]:
         try:
             event_uuid = uuid.UUID(event_id)
-            return await Event.select().where(Event.id == event_uuid).first()
+            return await Event.select().where(Event.id == event_uuid).output(load_json=True).first()
         except (ValueError, TypeError):
             return None
     
@@ -81,7 +81,7 @@ class DatabaseService:
         if not include_unapproved:
             query = query.where(Event.Approved == True)
             
-        return await query.order_by(Event.StartTime)
+        return await query.order_by(Event.StartTime).output(load_json=True)
     
     async def get_upcoming_events(self, include_unapproved: bool = False) -> List[Event]:
         now = datetime.now()
@@ -93,7 +93,7 @@ class DatabaseService:
         if not include_unapproved:
             query = query.where(Event.Approved == True)
             
-        return await query.order_by(Event.StartTime)
+        return await query.order_by(Event.StartTime).output(load_json=True)
     
     
     async def update_event(self, event_id: str, **updates) -> Optional[Event]:
@@ -118,7 +118,7 @@ class DatabaseService:
         try:
             event_uuid = uuid.UUID(event_id) 
             await Event.update(**updates).where(Event.id == event_uuid)
-            return await Event.select().where(Event.id == event_uuid).first()
+            return await Event.select().where(Event.id == event_uuid).output(load_json=True).first()
         except (ValueError, TypeError) as e:
             logging.error(e)
             return None
@@ -132,50 +132,90 @@ class DatabaseService:
             updates["RawCancellation"] = reason
         return await self.update_event(event_id, **updates)
     
-    async def toggle_user_interest(self, event_id: str, user_slack_id: str, forced_state: Optional[bool] = None) -> Optional[Event]:
+    async def toggle_user_interest(self, event_id: str, user_slack_id: str, forced_state: Optional[bool] = None, user_info: Optional[Dict[str, Any]] = None) -> Optional[Event]:
         try:
             event_uuid = uuid.UUID(event_id)
-            event = await Event.objects().where(Event.id == event_uuid).first()
+            event = await Event.objects().where(Event.id == event_uuid).output(load_json=True).first()
             
             if not event:
                 return None
-                
-            interested_users = list(event.InterestedUsers or [])
-            unupdated_users_set = set(interested_users)
             
+            rsvp_data = dict(event.RSVPData or {})
+            if isinstance(rsvp_data, str):
+                try:
+                    import json
+                    rsvp_data = json.loads(rsvp_data)
+                except Exception:
+                    rsvp_data = {}
+            legacy_users: list = list(event.InterestedUsers or [])
+
+            sub = user_info.get("sub") if user_info else None
+            rsvp_key = sub or user_slack_id
+
+            in_rsvp_data = rsvp_key in rsvp_data
+            in_legacy = user_slack_id in legacy_users
+            currently_attending = in_rsvp_data or in_legacy
+
             if forced_state is True:
-                if user_slack_id not in interested_users:
-                    interested_users.append(user_slack_id)
-         
+                should_attend = True
             elif forced_state is False:
-                if user_slack_id in interested_users:
-                    interested_users.remove(user_slack_id)
-            
-            elif forced_state == None:
-                if user_slack_id in interested_users:
-                    interested_users.remove(user_slack_id)
-                else:
-                    interested_users.append(user_slack_id)
+                should_attend = False
+            else:
+                should_attend = not currently_attending
 
+            if not should_attend and not currently_attending:
+                return await Event.select().where(Event.id == event_uuid).output(load_json=True).first()
 
-            if set(interested_users) == unupdated_users_set:
-                return event
+            if should_attend:
+                rsvp_data[rsvp_key] = {
+                    "sub" : sub,
+                    "slackId": user_slack_id,
+                    "name": user_info.get("name") if user_info else None,
+                    "email": user_info.get("email") if user_info else None,
+                    "slackDisplayName": user_info.get("slackDisplayName") if user_info else None,
+                    "rsvpedAt": datetime.now(timezone.utc).isoformat(),
+                }
+            else:
+                rsvp_data.pop(rsvp_key, None)
+                if user_slack_id != rsvp_key:
+                    rsvp_data.pop(user_slack_id, None)
+                stale = [k for k, v in rsvp_data.items() if v.get("slackId") == user_slack_id]
+                for k in stale:
+                    rsvp_data.pop(k)
+
+            rsvp_slack_ids = {v.get("slackId") for v in rsvp_data.values() if v.get("slackId")}
+            legacy_only = [uid for uid in legacy_users if uid not in rsvp_slack_ids]
+            new_count = len(rsvp_data) + len(legacy_only)
 
             await Event.update(
-                InterestedUsers=interested_users,
-                InterestCount=len(interested_users)
+                RSVPData=rsvp_data,
+                InterestCount=new_count,
+                # InterestedUsers - will no longer be written (exists in the backend for already RSVPed users btw)!
             ).where(Event.id == event_uuid)
-            
-            return await Event.select().where(Event.id == event_uuid).first()
-        except (ValueError, TypeError):
+            return await Event.select().where(Event.id == event_uuid).output(load_json=True).first()
+        except (ValueError, TypeError) as e:
+            logging.error("toggle_user_interest error: %s", e)
             return None
     
     async def get_interested_users(self, event_id: str) -> List[str]:
+        """legacy: returns union of slack IDs from both sources, we should remove InterestedUsers later tho"""
         event = await self.get_event(event_id)
 
         if not event:
             return []
-        return list(event.InterestedUsers or [])
+        legacy = list(event.get("InterestedUsers") or [])
+        rsvp_slack_ids = [
+            v["slackId"]
+            for v in (event.get("RSVPData") or {}).values()
+            if v.get("slackId")
+        ]
+        combined = list(legacy)
+        legacy_set = set(legacy)
+        for sid in rsvp_slack_ids:
+            if sid not in legacy_set:
+                combined.append(sid)
+
+        return combined
     
     async def set_rsvp_message(self, event_id: str, message_ts: str, channel_id: str, emoji: Optional[str] = None) -> bool:
         emoji_part = emoji or "any"
@@ -185,7 +225,7 @@ class DatabaseService:
         return result is not None
     
     async def get_event_by_rsvp(self, message_ts:str, channel_id:str, emoji: str) -> Optional[Event]:
-        event = await Event.select().where(Event.rsvpMsg == f"{message_ts}/{channel_id}/{emoji}").first()
+        event = await Event.select().where(Event.rsvpMsg == f"{message_ts}/{channel_id}/{emoji}").output(load_json=True).first()
 
         return event or None
 

--- a/isabelle/utils/env.py
+++ b/isabelle/utils/env.py
@@ -21,7 +21,8 @@ class Environment:
         self.sentry_dsn = os.environ.get("SENTRY_DSN", None)
         self.environemnt = os.environ.get("ENVIRONMENT", "development")
         self.slack_app_token = os.environ.get("SLACK_APP_TOKEN")
-
+        # for RSVPing
+        self.events_rsvp_secret = os.environ.get("EVENTS_RSVP_SECRET", "unset")
         self.port = int(os.environ.get("PORT", 3000))
 
         unset = [key for key, value in self.__dict__.items() if value == "unset"]

--- a/isabelle/utils/rsvp_checker.py
+++ b/isabelle/utils/rsvp_checker.py
@@ -24,6 +24,19 @@ async def send_reminder(
             email_addr, f"{event['Title']} Reminder!", message
         )
 
+def _slack_ids_for_event(event: dict[str, Any]) -> list[str]:
+    rsvp_data: dict = event.get("RSVPData") or {} 
+    legacy: list = event.get("InterestedUsers") or []
+    ids: list[str] = []
+    seen: set[str] = set()
+    for entry in rsvp_data.values():
+        sid = entry.get("slackId")
+        if sid and sid not in seen:
+            ids.append(sid); seen.add(sid)
+    for sid in legacy:
+        if sid and sid not in seen:
+            ids.append(sid); seen.add(sid)
+    return ids
 
 async def check_rsvps():
     logger.debug("Checking RSVPs")
@@ -33,15 +46,15 @@ async def check_rsvps():
         if not event["Approved"]:
             continue
         start_time = event["StartTime"].timestamp()
-        rsvps = event["InterestedUsers"]
+        slack_ids = _slack_ids_for_event(event)
 
         # Handle 1 day reminders
         if start_time - time.time() <= 86400 and not event.get(
             "Sent1DayReminder", False
         ):
-            for user in rsvps:
+            for user_id in slack_ids:
                 await send_reminder(
-                    user,
+                    user_id,
                     f"Hey! Just a reminder that {event['Title']} run by {event['Leader']} is tomorrow! Hope to see you there!",
                     event,
                 )
@@ -51,9 +64,9 @@ async def check_rsvps():
         elif start_time - time.time() <= 3600 and not event.get(
             "Sent1HourReminder", False
         ):
-            for user in rsvps:
+            for user_id in slack_ids:
                 await send_reminder(
-                    user,
+                    user_id,
                     f"Hey! Just a reminder that {event['Title']} run by {event['Leader']} starts in 1 hour! Hope to see you there!\nYou can join the event at {event.get('EventLink', 'the Slack!')}",
                     event,
                 )
@@ -63,9 +76,9 @@ async def check_rsvps():
             "SentStartingReminder", True
         ):
             pass
-            for user in rsvps:
+            for user_id in slack_ids:
                 await send_reminder(
-                    user,
+                    user_id,
                     f"Hey! Just a reminder that {event['Title']} run by {event['Leader']} has started!\nYou can join the event at {event.get('EventLink', 'the Slack!')}\nHope you enjoy it!",
                     event,
                     email=True,


### PR DESCRIPTION
## summary

added internal RSVP endpoints to be used by events.hackclub.com

### changes

- added authenticated internal RSVP endpoints:
  - `POST /internal/events/{id}/rsvp`
  - `GET /internal/events/{id}/rsvps`
- reused existing RSVP logic (`toggle_user_interest`) 
- removed `InterestedUsers` from the public events API/CRUD responses for privacy
- kept `InterestCount` publicly accessible

### why

this prepares Isabelle to act as the RSVP data layer for events.hackclub.com